### PR TITLE
refactor(ServiceThemeReact): Add dispose guard and improve update logic

### DIFF
--- a/lib/domain/services/service_theme_react.dart
+++ b/lib/domain/services/service_theme_react.dart
@@ -40,13 +40,19 @@ abstract class ServiceThemeReact {
   final BlocGeneral<Map<String, dynamic>> _themeStateJson =
       BlocGeneral<Map<String, dynamic>>(ThemeState.defaults.toJson());
 
+  bool _disposed = false;
+
   Stream<Map<String, dynamic>> get themeStream => _themeStateJson.stream;
   Map<String, dynamic> get themeStateJson => _themeStateJson.value;
 
   void updateTheme(Map<String, dynamic> json) {
-    if (themeStateJson != json) {
-      _themeStateJson.value = json;
+    if (_disposed) {
+      return;
     }
+    if (identical(themeStateJson, json)) {
+      return;
+    }
+    _themeStateJson.value = json;
   }
 
   void addFunctionToProcessValueOnStream(
@@ -64,6 +70,10 @@ abstract class ServiceThemeReact {
   }
 
   void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     _themeStateJson.dispose();
   }
 }

--- a/test/domain/services/service_theme_react_test.dart
+++ b/test/domain/services/service_theme_react_test.dart
@@ -25,7 +25,7 @@ void main() {
       final _FakeService s = _FakeService();
       final List<Map<String, dynamic>> events = <Map<String, dynamic>>[];
       final StreamSubscription<Map<String, dynamic>> sub =
-          s.themeStream.listen(events.add);
+          s.themeStream.skip(1).listen(events.add);
 
       // Primer update con la misma referencia del valor actual
       final Map<String, dynamic> sameRef = s.themeStateJson;
@@ -50,7 +50,7 @@ void main() {
       final _FakeService s = _FakeService();
       final List<Map<String, dynamic>> events = <Map<String, dynamic>>[];
       final StreamSubscription<Map<String, dynamic>> sub =
-          s.themeStream.listen(events.add);
+          s.themeStream.skip(1).listen(events.add);
 
       // Clonar el JSON actual (contenido igual, instancia diferente)
       final Map<String, dynamic> clone =
@@ -117,10 +117,11 @@ void main() {
       s.deleteFunctionToProcessValueOnStream(
         'mark',
       );
-
+      await Future<void>.delayed(const Duration(milliseconds: 10));
       // Segunda emisión: ya no debe venir marcado
-      final Map<String, dynamic> b = Map<String, dynamic>.from(events.last)
-        ..['preset'] = 'p2';
+      final Map<String, dynamic> b =
+          Map<String, dynamic>.from(ThemeState.defaults.toJson())
+            ..['preset'] = 'p2';
       s.updateTheme(b);
       await Future<void>.delayed(const Duration(milliseconds: 10));
       expect(events.last['__mark'], isNull);


### PR DESCRIPTION
- Add a `_disposed` flag to prevent state updates or stream events after the service has been disposed.
- In `updateTheme`, add a guard to do nothing if the new JSON object is identical to the current one, preventing unnecessary stream events.
- Refine tests to handle this improved behavior, specifically by skipping the initial state event from the stream and adjusting assertions for updates with identical and cloned data.