### PR TITLE
Dev/hotfix hybrid env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [3.4.1] - 2025-11-04
+
+### Fixed
+- **Lints / Docs:**
+    - Corrige advertencia _“Angle brackets will be interpreted as HTML”_ en DartDoc (`theme_usecases.dart`) escapando o envolviendo con código para tipos genéricos (`Either<ErrorItem, ThemeState>`).
+- **UI (deprecations):**
+    - Reemplazo de `toastStream` **deprecated** en `page_builder.dart`:
+        - Ahora se usa `textStream` (solo texto) **o** `stream<ToastMessage>` según el caso, eliminando la dependencia de la API obsoleta.
+
+### Changed
+- **env (DI/testability)** — `hotfix(env): refactor Env for improved DI and testability`
+    - `Env` pasa de diseño estático a **modelo basado en instancias**:
+        - Convertido a `abstract class`; `isQa`, `isProd`, `mode` ahora son **getters de instancia**.
+        - La variable de compilación `_mode` continúa siendo `static`, pero se **encapsula** detrás de la instancia.
+    - **`DefaultEnv`**: implementación estándar por defecto.
+    - **Testing:** se añade `modeTest` opcional para **forzar modo** en pruebas.
+- **AppManager**
+    - Ahora **recibe un `Env`** en el constructor (por defecto, `DefaultEnv`).
+    - `appMode`, `isQa`, `isProd` delegan al `Env` **inyectado** (no más accesores estáticos).
+
+### Docs
+- Actualizada la documentación de `Env` y ejemplo práctico de uso con DI.
+- Notas en `page_builder.dart` sobre el uso de `textStream`/`ToastMessage` en lugar de `toastStream`.
+
+### Migration notes
+- **Casi sin rompimientos**:
+    - Si no pasas `Env`, **no debes cambiar nada** (usa `DefaultEnv`).
+    - Para pruebas o entornos custom, inyecta tu instancia:
+      ```dart
+      final Env env = DefaultEnv(modeTest: AppMode.qa); // o tu implementación
+      final AppManager am = AppManager(env: env);
+      ```
+    - Si tu UI usaba `toastStream` directamente, migra a:
+        - `textStream` (cuando solo necesitas texto), o
+        - un `Stream<ToastMessage>` si manejas tipos enriquecidos.
+
 ## [3.4.0] - 2025-11-03
 
 > Versión **acumulada** que integra las entregas **3.3.2** (flavors lógicos por `--dart-define`) y **3.3.1** (página y web de Política de Privacidad, y estructura legal unificada). No introduce cambios adicionales fuera de lo ya incluido.

--- a/lib/domain/blocs/app_manager.dart
+++ b/lib/domain/blocs/app_manager.dart
@@ -15,9 +15,15 @@ part of 'package:jocaaguraarchetype/jocaaguraarchetype.dart';
 /// - `home` behaves as singleTop via [clearAndGoHome].
 /// - Pages may set `requiresAuth`; coordinator redirects to `/login`.
 class AppManager {
-  AppManager(this._config, {this.onAppLifecycleChanged});
+  AppManager(
+    this._config, {
+    this.onAppLifecycleChanged,
+    this.env = defaultEnv,
+  });
   AppConfig _config;
   bool _disposed = false;
+
+  final Env env;
   final void Function(AppLifecycleState state)? onAppLifecycleChanged;
   // ---- Read-only accessors to core blocs ----
   BlocTheme get theme => _config.blocTheme;
@@ -45,6 +51,13 @@ class AppManager {
   void handleLifecycle(AppLifecycleState state) {
     onAppLifecycleChanged?.call(state);
   }
+
+  // --------------------------------------------------------------------------
+  // Enviroment -
+  // --------------------------------------------------------------------------
+  AppMode get appMode => env.mode;
+  bool get isQa => env.isQa;
+  bool get isProd => env.isProd;
 
   // --------------------------------------------------------------------------
   // Navigation API (String-based; internamente PageModel.fromUri)

--- a/lib/domain/usecases/theme/theme_usecases.dart
+++ b/lib/domain/usecases/theme/theme_usecases.dart
@@ -227,7 +227,7 @@ class SetTextThemeOverrides with _ThemeUpdate {
 
 /// Streams theme updates from the repository.
 ///
-/// Emits Either<ErrorItem, ThemeState> so the consumer can handle errors
+/// Emits `Either<ErrorItem, ThemeState>` so the consumer can handle errors
 /// without closing the stream.
 class WatchTheme {
   const WatchTheme(this.repo);

--- a/lib/env/env.dart
+++ b/lib/env/env.dart
@@ -1,25 +1,64 @@
 part of 'package:jocaaguraarchetype/jocaaguraarchetype.dart';
 
-/// Minimal environment reader intended to be **extended per project**.
-/// Only carries the mode; concrete apps should subclass and add their own keys.
+/// Base Environment contract to be **extended per project**.
 ///
-/// Example
+/// - `_mode` is **static** and resolved at compile time from `--dart-define`.
+/// - Instance getters (`mode`, `isQa`, `isProd`) delegate to the static `_mode`,
+///   so subclasses only add project-specific keys.
+///
+/// # Usage
 /// ```dart
 /// class MyEnv extends Env {
-///   static const String apiBaseUrl = String.fromEnvironment('API_BASE_URL');
+///   const MyEnv({
+///     this.apiBaseUrl = const String.fromEnvironment('API_BASE_URL'),
+///   });
+///
+///   /// Project-specific key.
+///   final String apiBaseUrl;
 /// }
-/// final AppMode mode = Env.mode;
+///
+/// void main() {
+///   // Prefer explicit DI: pass an Env instance down your App layer.
+///   const MyEnv env = MyEnv();
+///   runApp(MyApp(env: env));
+/// }
+///
+/// // Inside your AppManager / DI root:
+/// class AppManager {
+///   const AppManager({required this.env});
+///   final Env env;
+/// }
+///
+/// // Anywhere below, depend on Env via DI:
+/// class ProductsRepository {
+///   const ProductsRepository({required this.env});
+///   final MyEnv env; // or Env if you want to keep it generic
+///
+///   Uri get baseUri => Uri.parse(env.apiBaseUrl);
+/// }
 /// ```
-class Env {
+abstract class Env {
+  /// Instance constructor (subclasses add their own keys).
+  const Env([this.modeTest]);
+
+  final String? modeTest;
+
+  /// Raw mode from `--dart-define=APP_MODE=dev|qa|prod` (compile-time).
   static const String _mode =
       String.fromEnvironment('APP_MODE', defaultValue: 'dev');
 
-  /// True when running against QA backend/services.
-  static bool get isQa => _mode == 'qa';
+  /// Instance: current [AppMode] (delegates to static).
+  AppMode get mode => parseAppMode(modeTest ?? _mode);
 
-  /// True when running against PROD backend/services.
-  static bool get isProd => _mode == 'prod';
+  /// Instance: true when QA (delegates to static).
+  bool get isQa => mode == AppMode.qa;
 
-  /// Current [AppMode] parsed from `APP_MODE`.
-  static AppMode get mode => parseAppMode(_mode);
+  /// Instance: true when PROD (delegates to static).
+  bool get isProd => mode == AppMode.prod;
 }
+
+class DefaultEnv extends Env {
+  const DefaultEnv(super.modeTest);
+}
+
+const Env defaultEnv = DefaultEnv(null);

--- a/lib/ui/page_builder.dart
+++ b/lib/ui/page_builder.dart
@@ -152,7 +152,7 @@ class PageBuilder extends StatelessWidget {
                           ),
                           MySnackBarWidget.fromStringStream(
                             responsive: r,
-                            toastStream: app.notifications.toastStream,
+                            toastStream: app.notifications.textStream,
                           ),
                         ],
                       ),


### PR DESCRIPTION
## [3.4.1] - 2025-11-04

### Fixed
- **Lints / Docs:**
    - Corrige advertencia _“Angle brackets will be interpreted as HTML”_ en DartDoc (`theme_usecases.dart`) escapando o envolviendo con código para tipos genéricos (`Either<ErrorItem, ThemeState>`).
- **UI (deprecations):**
    - Reemplazo de `toastStream` **deprecated** en `page_builder.dart`:
        - Ahora se usa `textStream` (solo texto) **o** `stream<ToastMessage>` según el caso, eliminando la dependencia de la API obsoleta.

### Changed
- **env (DI/testability)** — `hotfix(env): refactor Env for improved DI and testability`
    - `Env` pasa de diseño estático a **modelo basado en instancias**:
        - Convertido a `abstract class`; `isQa`, `isProd`, `mode` ahora son **getters de instancia**.
        - La variable de compilación `_mode` continúa siendo `static`, pero se **encapsula** detrás de la instancia.
    - **`DefaultEnv`**: implementación estándar por defecto.
    - **Testing:** se añade `modeTest` opcional para **forzar modo** en pruebas.
- **AppManager**
    - Ahora **recibe un `Env`** en el constructor (por defecto, `DefaultEnv`).
    - `appMode`, `isQa`, `isProd` delegan al `Env` **inyectado** (no más accesores estáticos).

### Docs
- Actualizada la documentación de `Env` y ejemplo práctico de uso con DI.
- Notas en `page_builder.dart` sobre el uso de `textStream`/`ToastMessage` en lugar de `toastStream`.

### Migration notes
- **Casi sin rompimientos**:
    - Si no pasas `Env`, **no debes cambiar nada** (usa `DefaultEnv`).
    - Para pruebas o entornos custom, inyecta tu instancia:
      ```dart
      final Env env = DefaultEnv(modeTest: AppMode.qa); // o tu implementación
      final AppManager am = AppManager(env: env);
      ```
    - Si tu UI usaba `toastStream` directamente, migra a:
        - `textStream` (cuando solo necesitas texto), o
        - un `Stream<ToastMessage>` si manejas tipos enriquecidos.
