### PR TITLE
Dev/upgrade jocaagura domain to 1390

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2026-03-24
+
+### Changed
+- Dependencia `jocaagura_domain` actualizada y alineada a `1.39.0`.
+- Validada la retrocompatibilidad del arquetipo con `jocaagura_domain 1.39.0` en compilación, análisis y pruebas.
+
+### Docs
+- README general reestructurado para reflejar el estado actual del arquetipo.
+- Se documentó explícitamente la compatibilidad con `jocaagura_domain 1.39.0`.
+- Se añadió un bloque destacado para enfatizar el soporte nativo del paquete a Design System:
+  - `ModelDesignSystem`
+  - `ModelThemeData`
+  - `ModelDsExtendedTokens`
+  - `ModelSemanticColors`
+  - `ModelDataVizPalette`
+  - `BlocDesignSystem`
+  - widgets de edición e import/export
+
+### Compatibility
+- Upgrade considerado retrocompatible para `jocaaguraarchetype`.
+- No se requirieron ajustes funcionales obligatorios en widgets, flujos, formularios ni bootstrap transversal.
+
 ## [4.1.0] - 2026-01-21
 
 > **Release acumulada** que integra **4.0.1 → 4.0.6**. Enfoque: Sistema de Diseño serializable, utilidades de ACL, y toolchain para análisis/simulación de flujos.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,103 @@
 # JocaaguraArchetype
 
-> ⚠️ **Heads-up:** Documentation is in progress. We’re migrating cross-cutting concerns to [`jocaagura_domain`](https://pub.dev/packages/jocaagura_domain).  
-> This archetype stays available as a UI shell and app scaffold. Expect incremental updates.
+Arquetipo base para aplicaciones Flutter con enfoque de Clean Architecture, BLoCs transversales, navegación, theming y utilidades reutilizables sobre `jocaagura_domain`.
 
----
+## Estado actual
 
-## Quick start
+- Dependencia alineada con `jocaagura_domain: ^1.39.0`.
+- Validación de compatibilidad completada con:
+  - `flutter pub get`
+  - `flutter analyze`
+  - `flutter test`
+- Resultado del upgrade a `1.39.0`: retrocompatible para el arquetipo, sin cambios obligatorios de adopción.
+
+## Qué resuelve este arquetipo
+
+Este paquete sirve como base estable para nuevas apps que necesiten:
+
+- bootstrap de aplicación y sesión
+- navegación con `PageRegistry`, `PageManager` y coordinadores
+- responsividad con `BlocResponsive`
+- theming reactivo y persistible
+- formularios controlados con `ModelFieldState`
+- soporte para ACL, flujos `Either` y utilidades transversales
+
+La idea práctica es esta:
+
+```text
+UI -> AppManager -> Bloc -> UseCase -> Repository -> Gateway -> Service
+```
+
+El arquetipo orquesta la capa de aplicación y UI, mientras `jocaagura_domain` concentra contratos, modelos, BLoCs base, helpers y utilidades compartidas.
+
+## Soporte destacado para Design System
+
+El paquete no trata el Design System como un detalle cosmético, sino como una capacidad de primer nivel del arquetipo.
+
+Eso significa que puedes trabajar el sistema visual como un activo versionable, serializable y reusable entre apps, ambientes o snapshots de configuración.
+
+Incluye soporte práctico para:
+
+- `ModelDesignSystem` como contenedor integral del sistema visual
+- `ModelThemeData` para representar `ThemeData` de forma serializable
+- `ModelDsExtendedTokens` para spacing, radius, elevation, alpha y duraciones
+- `ModelSemanticColors` para colores semánticos consistentes
+- `ModelDataVizPalette` para paletas orientadas a visualización de datos
+- `BlocDesignSystem` para actualizar y propagar cambios de forma reactiva
+- widgets como `DsTextThemeEditorWidget` y `DsImportExportWidget`
+
+En términos simples: no solo puedes pintar una app, también puedes modelar, persistir, editar, importar, exportar y evolucionar su lenguaje visual sin repartir lógica visual por toda la UI.
+
+## Compatibilidad con `jocaagura_domain 1.39.0`
+
+Se verificó el consumo del arquetipo contra la versión `1.39.0`, poniendo atención en las piezas más sensibles:
+
+- `ModelAppVersion`
+- `JocaDateUtils` y normalización ISO usada por snapshots/modelos
+- `BlocModule`
+- `BlocResponsive`
+- patrón de formularios con `ModelFieldState`
+- widgets transversales, theme, responsive y bootstrap de app
+
+Conclusión:
+
+- no se detectaron imports rotos por barrels o módulos expuestos
+- el arquetipo compila y analiza correctamente con `1.39.0`
+- los tests existentes pasan sin requerir adaptaciones funcionales
+- el upgrade se considera aditivo y retrocompatible para este repositorio
+
+## Instalación
+
+En tu `pubspec.yaml`:
+
+```yaml
+dependencies:
+  jocaaguraarchetype: ^4.1.0
+  jocaagura_domain: ^1.39.0
+```
+
+Luego:
+
+```bash
+flutter pub get
+```
+
+## Quick Start
 
 ```dart
 import 'package:flutter/material.dart';
 import 'package:jocaaguraarchetype/jocaaguraarchetype.dart';
 
 void main() {
-  // Dev profile: in-memory gateways, fake services, and debug flags on.
   final AppConfig config = AppConfig.dev();
 
-  // Minimal page registry
   final PageRegistry registry = PageRegistry(
     routes: <String, WidgetBuilder>{
       '/': (_) => const MyDemoHomePage(),
-      '/onboarding': (_) => const OnboardingPage(steps: <Widget>[], onFinish: null),
+      '/onboarding': (_) => const OnboardingPage(
+            steps: <Widget>[],
+            onFinish: null,
+          ),
     },
     notFoundBuilder: (_) => const Page404Widget(),
   );
@@ -31,79 +109,124 @@ void main() {
     ),
   );
 }
-````
+```
 
-### Toggle theme (example)
+## Ejemplo de uso de `AppManager`
 
 ```dart
-void main() async{
-// Somewhere in the UI:
+void main()async{
   final AppManager app = AppManagerProvider.of(context);
-
-// App-level actions via ThemeUsecases:
   await app.themeUsecases.toggleMaterial3();
   await app.themeUsecases.setSeedColor(const Color(0xFF6750A4));
   await app.themeUsecases.setMode(ThemeMode.dark);
 }
 ```
 
----
+Además del theming, desde `AppManager` puedes centralizar acceso a:
 
-## Architecture
+- `BlocResponsive`
+- `BlocOnboarding`
+- `BlocModelVersion`
+- módulos registrados en `blocModuleList`
+- navegación y estado transversal de la app
 
-We follow Clean Architecture aligned with `jocaagura_domain`:
+## Componentes principales
 
+### App bootstrap
+
+- `AppConfig`: compone BLoCs y módulos base.
+- `JocaaguraApp`: punto de entrada para apps basadas en el arquetipo.
+- `AppManager`: fachada de acceso a estado, navegación y módulos transversales.
+
+### Navegación
+
+- `PageRegistry`: registro declarativo de páginas.
+- `PageManager`: navegación reactiva y estado de pila.
+- `SessionNavCoordinator`: coordinación de flujos vinculados a sesión.
+
+### Responsive
+
+- `BlocResponsive`: punto único para decisiones de layout.
+- builders y widgets responsive listos para reutilizar.
+
+### Theming y Design System
+
+- `BlocTheme`, `BlocThemeReact`, `ThemeUsecases`
+- modelos serializables como `ModelThemeData`, `ModelDesignSystem`, `ModelDsExtendedTokens`
+- `BlocDesignSystem` para manejo reactivo del DS
+- widgets de edición/import-export para configuraciones visuales
+
+### Forms
+
+- `ModelFieldState` como estado controlado de inputs
+- widgets reutilizables para inputs y autocomplete
+
+### ACL y Either Flow
+
+- `BlocAcl`, `AclBridge`, `ModelAclSnapshot`
+- utilidades de análisis, validación y simulación de flujos `Either`
+
+## Estructura recomendada
+
+```text
+lib/
+  domain/
+    blocs/
+    entities/
+    gateways/
+    models/
+    repositories/
+    services/
+    states/
+    usecases/
+  ui/
+    builders/
+    navigation/
+    pages/
+    providers/
+    theme/
+    widgets/
+  either_flow/
+  env/
+  src/
 ```
-UI → AppManager → Bloc → UseCase → Repository → Gateway → Service
+
+## Validación recomendada al integrar cambios de dominio
+
+Si actualizas `jocaagura_domain`, esta es la secuencia mínima recomendada:
+
+```bash
+flutter pub get
+flutter analyze
+flutter test
+cd example
+flutter analyze
 ```
 
-* **BLoCs** use `BlocGeneral<T>` from `jocaagura_domain`.
-* **Theme**: `ThemeUsecases` + `RepositoryTheme` + `GatewayTheme` + `ServiceJocaaguraArchetypeTheme`.
+Esto ayuda a detectar rápido tres tipos de regresión:
 
-Refer to the structure guide:
-[https://github.com/grupo-jocaagura/jocaagura\_domain/raw/refs/heads/develop/README\_STRUCTURE.md](https://github.com/grupo-jocaagura/jocaagura_domain/raw/refs/heads/develop/README_STRUCTURE.md)
+- contratos o imports rotos
+- cambios de tipos o helpers compartidos
+- efectos colaterales en widgets, navegación o bootstrap
 
----
-
-## Lints and style
-
-We adopt the shared rules:
-[https://github.com/grupo-jocaagura/jocaagura\_domain/raw/refs/heads/develop/analysis\_options.yaml](https://github.com/grupo-jocaagura/jocaagura_domain/raw/refs/heads/develop/analysis_options.yaml)
-
-* Prefer explicit types in locals (`final List<T> items = <T>[];`).
-* Avoid `print`/`debugPrint` in production code; use an injected logger.
-
----
-
-## Contributing & CI
-
-Branch strategy:
-
-* `develop` for day-to-day work (PR-only).
-* `master` for releases (merge from `develop`).
-
-Recommended workflows:
-
-* Validate PR to develop:
-  [https://github.com/grupo-jocaagura/jocaagura\_domain/raw/refs/heads/develop/.github/workflows/validate\_pr.yaml](https://github.com/grupo-jocaagura/jocaagura_domain/raw/refs/heads/develop/.github/workflows/validate_pr.yaml)
-* Validate PR to master:
-  [https://github.com/grupo-jocaagura/jocaagura\_domain/raw/refs/heads/develop/.github/workflows/validate\_pr\_master.yaml](https://github.com/grupo-jocaagura/jocaagura_domain/raw/refs/heads/develop/.github/workflows/validate_pr_master.yaml)
-
-Security & quality:
-
-* CodeQL for `develop` and `master`.
-* Signed commits enforced (GitHub bot setup).
-
-> Full docs are being completed. We’ll expand with more samples (routing, PageBuilder, responsive widgets) soon.
-
----
-
-## Documentation
+## Documentación complementaria
 
 - [Responsive Flow & BlocResponsive Pattern](doc/responsive-flow.md)
 
----
+## Contribución
 
-## License
+Flujo recomendado:
+
+- `develop` para trabajo diario vía PR
+- `master` para releases
+
+Criterios prácticos para contribuir:
+
+- priorizar cambios pequeños y verificables
+- mantener separación clara de responsabilidades
+- evitar acoplar UI con detalles de infraestructura
+- acompañar cambios transversales con tests y notas de migración cuando aplique
+
+## Licencia
 
 MIT (c) Jocaagura

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  jocaagura_domain: ^1.38.1
+  jocaagura_domain: ^1.39.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION

### Changed
- Dependencia `jocaagura_domain` actualizada y alineada a `1.39.0`.
- Validada la retrocompatibilidad del arquetipo con `jocaagura_domain 1.39.0` en compilación, análisis y pruebas.

### Docs
- README general reestructurado para reflejar el estado actual del arquetipo.
- Se documentó explícitamente la compatibilidad con `jocaagura_domain 1.39.0`.
- Se añadió un bloque destacado para enfatizar el soporte nativo del paquete a Design System:
  - `ModelDesignSystem`
  - `ModelThemeData`
  - `ModelDsExtendedTokens`
  - `ModelSemanticColors`
  - `ModelDataVizPalette`
  - `BlocDesignSystem`
  - widgets de edición e import/export

### Compatibility
- Upgrade considerado retrocompatible para `jocaaguraarchetype`.
- No se requirieron ajustes funcionales obligatorios en widgets, flujos, formularios ni bootstrap transversal.
